### PR TITLE
Error handler for socket errors to prevent server crash

### DIFF
--- a/src/livereload-server.coffee
+++ b/src/livereload-server.coffee
@@ -23,6 +23,8 @@ class Server
   handleConnection: (socket) ->
     client = new Client socket
     @clients.push client
+    socket.on 'error', (err) ->
+      console.log(err)
     socket.on 'close', =>
       idx = @clients.indexOf client
       @clients.splice idx, 1


### PR DESCRIPTION
This prevents server crashing for socket errors that I have experienced when using chrome with livereload. This however does not solve the root cause of why the socket error is happening. Need more work to solve this.